### PR TITLE
Fix for BeagleBoardXM USB Gadget running Ubuntu core 11.10

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -18,6 +18,8 @@ patch -s -p1 < "${DIR}/patches/trivial/0001-kbuild-deb-pkg-set-host-machine-afte
 #should fix gcc-4.6 ehci problems..
 patch -s -p1 < "${DIR}/patches/trivial/0001-USB-ehci-use-packed-aligned-4-instead-of-removing-th.patch"
 
+patch -s -p1 < "${DIR}/patches/trivial/0001-USB-DUALSPEED-Gadget-KConfig.patch"
+
 }
 
 function cpufreq {

--- a/patches/trivial/0001-USB-DUALSPEED-Gadget-KConfig.patch
+++ b/patches/trivial/0001-USB-DUALSPEED-Gadget-KConfig.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/usb/musb/Kconfig b/drivers/usb/musb/Kconfig
+index fc34b8b..602d51c 100644
+--- a/drivers/usb/musb/Kconfig
++++ b/drivers/usb/musb/Kconfig
+@@ -10,6 +10,7 @@ config USB_MUSB_HDRC
+ 	select NOP_USB_XCEIV if (ARCH_DAVINCI || MACH_OMAP3EVM || BLACKFIN)
+ 	select TWL4030_USB if MACH_OMAP_3430SDP
+ 	select TWL6030_USB if MACH_OMAP_4430SDP || MACH_OMAP4_PANDA
++	select USB_GADGET_DUALSPEED
+ 	select USB_OTG_UTILS
+ 	tristate 'Inventra Highspeed Dual Role Controller (TI, ADI, ...)'
+ 	help


### PR DESCRIPTION
Fix via
http://marc.info/?l=linux-usb&m=132091252718281&w=2
