### PR TITLE
Add the ability to specify buddy=spidev and enable spi 3 and 4

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -104,7 +104,7 @@ beagle () {
 	git am "${DIR}/patches/beagle/0016-ASoC-omap-convert-per-board-modules-to-platform-driv.patch"
 	git am "${DIR}/patches/beagle/0017-Beagle-expansion-zippy1-2-rework-mmc-i2c-handling.patch"
 	git am "${DIR}/patches/beagle/0018-Beagle-expansion-add-beaglefpga.patch"
-
+	git am "${DIR}/patches/beagle/0019-Enable-buddy-spidev.patch"
 }
 
 devkit8000 () {

--- a/patches/beagle/0019-Enable-buddy-spidev.patch
+++ b/patches/beagle/0019-Enable-buddy-spidev.patch
@@ -1,0 +1,31 @@
+From 91160821dafea602df5965f3b75fd6f50623014f Mon Sep 17 00:00:00 2001
+From: Russell Hay <russell.hay@gmail.com>
+Date: Mon, 28 May 2012 09:45:24 -0700
+Subject: [PATCH] Enable buddy=spidev
+
+---
+ arch/arm/mach-omap2/board-omap3beagle.c |    8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm/mach-omap2/board-omap3beagle.c b/arch/arm/mach-omap2/board-omap3beagle.c
+index 538bdfd..c72da95 100644
+--- a/arch/arm/mach-omap2/board-omap3beagle.c
++++ b/arch/arm/mach-omap2/board-omap3beagle.c
+@@ -1106,6 +1106,14 @@ static void __init omap3_beagle_init(void)
+ 		omap3beagle_tsc2007_init();
+ 	}
+ 
++	if (!strcmp(expansionboard_name, "spidev"))
++	{
++		printk(KERN_INFO "Beagle expansionboard: registering SPIDEV");
++		omap3_beagle_config_mcspi3_mux();
++		omap3_beagle_config_mcspi4_mux();
++		spi_register_board_info(beagle_mcspi_board_info, ARRAY_SIZE(beagle_mcspi_board_info));
++	}
++
+ 	usb_musb_init(NULL);
+ 	usbhs_init(&usbhs_bdata);
+ 	omap_nand_flash_init(NAND_BUSWIDTH_16, omap3beagle_nand_partitions,
+-- 
+1.7.9.5
+


### PR DESCRIPTION
The current version of 3.2.18-x12 doesn't allow you to easily enable spidev.  This patch allows you to specify buddy=spidev to enable spi 3 and 4 on the beagleboard.
